### PR TITLE
增加转发http数据包到其他代理软件功能

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,95 @@
-# 功能场景
+# r0capture
 
-目前r0capture是以pcap和print的方式查看数据包，有时在应对渗透测试的场景下，需要用到burpsuite或yakit此类工具进行改包，方便进行数据包的分析和修改。
+安卓应用层抓包通杀脚本
 
-# 新增参数
+## 简介
 
-`-F http://127.0.0.1:8080` 或 `--isForward http://127.0.0.1:8080`
+- 仅限安卓平台，测试安卓7、8、9、10、11、12 可用 ；
+- 无视所有证书校验或绑定，不用考虑任何证书的事情；
+- 通杀TCP/IP四层模型中的应用层中的全部协议；
+- 通杀协议包括：Http,WebSocket,Ftp,Xmpp,Imap,Smtp,Protobuf等等、以及它们的SSL版本；
+- 通杀所有应用层框架，包括HttpUrlConnection、Okhttp1/3/4、Retrofit/Volley等等；
+- 无视加固，不管是整体壳还是二代壳或VMP，不用考虑加固的事情；
+- 如果有抓不到的情况欢迎提issue，或者直接加vx：r0ysue，进行反馈~
 
-`python r0capture.py -U -f package -F http://127.0.0.1:8080 -p test.pcap`
+### January.14th 2021 update：增加几个辅助功能
 
-# 演示效果
+- 增加App收发包函数定位功能
+- 增加App客户端证书导出功能
+- 新增host连接方式“-H”，用于Frida-server监听在非标准端口时的连接
 
-![image](https://user-images.githubusercontent.com/30547741/215651947-a84a2152-96bb-4c28-837c-f8117bc08445.png)
+## 用法
 
-![image](https://user-images.githubusercontent.com/30547741/215652029-9ae633da-1152-4721-93c6-9d5f7a919937.png)
+- 推荐环境：[https://github.com/r0ysue/AndroidSecurityStudy/blob/master/FRIDA/A01/README.md](https://github.com/r0ysue/AndroidSecurityStudy/blob/master/FRIDA/A01/README.md)
 
-# Tip
+切记仅限安卓平台7、8、9、10、11 可用 ，禁止使用模拟器。
 
-实现的forward只是对r0capture的SSL_write类型的function进行了处理，同时因为是hook的原因，并不能达到像平常代理那样的阻塞方式的拦截数据包。不过这也方便渗透测试人员对数据包的分析和测试 :)
+- Spawn 模式：
+
+`$ python3 r0capture.py -U -f com.qiyi.video -v`
+
+- Attach 模式，抓包内容保存成pcap文件供后续分析：
+
+`$ python3 r0capture.py -U com.qiyi.video -v -p iqiyi.pcap`
+
+建议使用`Attach`模式，从感兴趣的地方开始抓包，并且保存成`pcap`文件，供后续使用Wireshark进行分析。
+
+![](pic/Sample.PNG)
+
+- 收发包函数定位：`Spawn`和`attach`模式均默认开启；
+
+> 可以使用`python r0capture.py -U -f cn.soulapp.android -v  >> soul3.txt`这样的命令将输出重定向至txt文件中稍后过滤内容
+
+![](pic/locator.png)
+
+- 客户端证书导出功能：默认开启；必须以Spawm模式运行；
+
+> 运行脚本之前必须手动给App加上存储卡读写权限；
+
+> 并不是所有App都部署了服务器验证客户端的机制，只有配置了的才会在Apk中包含客户端证书
+
+> 导出后的证书位于/sdcard/Download/包名xxx.p12路径，导出多次，每一份均可用，密码默认为：r0ysue，推荐使用[keystore-explorer](http://keystore-explorer.org/)打开查看证书。
+
+![](pic/clientcer.png)
+
+- 新增host连接方式“-H”，用于Frida-server监听在非标准端口时的连接。有些App会检测Frida标准端口，因此frida-server开在非标准端口可以绕过检测。
+
+![](pic/difport.png)
+
+## 感谢[爱吃菠菜](https://bbs.pediy.com/user-760871.htm)巨巨总结的本项目知识点
+
+![](pic/summary1.jpg)
+![](pic/summary2.jpg)
+
+
+PS：
+
+> 这个项目基于[frida_ssl_logger](https://github.com/BigFaceCat2017/frida_ssl_logger)，之所以换个名字，只是侧重点不同。 原项目的侧重点在于抓ssl和跨平台，本项目的侧重点是抓到所有的包。
+
+> 局限：部分开发实力过强的大厂或框架，采用的是自身的SSL框架，比如WebView、小程序或Flutter，这部分目前暂未支持。部分融合App本质上已经不属于安卓App，没有使用安卓系统的框架，无法支持。当然这部分App也是少数。暂不支持HTTP/2、或HTTP/3，该部分API在安卓系统上暂未普及或布署，为App自带，无法进行通用hook。各种模拟器架构、实现、环境较为复杂，建议珍爱生命、使用真机。暂未添加多进程支持，比如:service或:push等子进程，可以使用Frida的Child-gating来支持一下。支持多进程之后要考虑pcap文件的写入锁问题，可以用frida-tool的Reactor线程锁来支持一下。
+
+## 以下是原项目的简介：
+
+[https://github.com/BigFaceCat2017/frida_ssl_logger](https://github.com/BigFaceCat2017/frida_ssl_logger)
+
+### frida_ssl_logger
+ssl_logger based on frida
+for from https://github.com/google/ssl_logger
+
+### 修改内容
+1. 优化了frida的JS脚本，修复了在新版frida上的语法错误；
+2. 调整JS脚本，使其适配iOS和macOS，同时也兼容了Android；
+3. 增加了更多的选项，使其能在多种情况下使用；
+
+### 安装依赖
+```
+Python版本>=3.6
+pip install loguru
+pip install click
+```
+### Usage
+  ```shell
+    python3 ./ssl_logger.py  -U -f com.bfc.mm
+    python3 ./ssl_logger.py -v  -p test.pcap  6666
+  ````
+

--- a/README.md
+++ b/README.md
@@ -1,95 +1,19 @@
-# r0capture
+# 功能场景
 
-安卓应用层抓包通杀脚本
+目前r0capture是以pcap和print的方式查看数据包，有时在应对渗透测试的场景下，需要用到burpsuite或yakit此类工具进行改包，方便进行数据包的分析和修改。
 
-## 简介
+# 新增参数
 
-- 仅限安卓平台，测试安卓7、8、9、10、11、12 可用 ；
-- 无视所有证书校验或绑定，不用考虑任何证书的事情；
-- 通杀TCP/IP四层模型中的应用层中的全部协议；
-- 通杀协议包括：Http,WebSocket,Ftp,Xmpp,Imap,Smtp,Protobuf等等、以及它们的SSL版本；
-- 通杀所有应用层框架，包括HttpUrlConnection、Okhttp1/3/4、Retrofit/Volley等等；
-- 无视加固，不管是整体壳还是二代壳或VMP，不用考虑加固的事情；
-- 如果有抓不到的情况欢迎提issue，或者直接加vx：r0ysue，进行反馈~
+`-F http://127.0.0.1:8080` 或 `--isForward http://127.0.0.1:8080`
 
-### January.14th 2021 update：增加几个辅助功能
+`python r0capture.py -U -f package -F http://127.0.0.1:8080 -p test.pcap`
 
-- 增加App收发包函数定位功能
-- 增加App客户端证书导出功能
-- 新增host连接方式“-H”，用于Frida-server监听在非标准端口时的连接
+# 演示效果
 
-## 用法
+![image](https://user-images.githubusercontent.com/30547741/215651947-a84a2152-96bb-4c28-837c-f8117bc08445.png)
 
-- 推荐环境：[https://github.com/r0ysue/AndroidSecurityStudy/blob/master/FRIDA/A01/README.md](https://github.com/r0ysue/AndroidSecurityStudy/blob/master/FRIDA/A01/README.md)
+![image](https://user-images.githubusercontent.com/30547741/215652029-9ae633da-1152-4721-93c6-9d5f7a919937.png)
 
-切记仅限安卓平台7、8、9、10、11 可用 ，禁止使用模拟器。
+# Tip
 
-- Spawn 模式：
-
-`$ python3 r0capture.py -U -f com.qiyi.video -v`
-
-- Attach 模式，抓包内容保存成pcap文件供后续分析：
-
-`$ python3 r0capture.py -U com.qiyi.video -v -p iqiyi.pcap`
-
-建议使用`Attach`模式，从感兴趣的地方开始抓包，并且保存成`pcap`文件，供后续使用Wireshark进行分析。
-
-![](pic/Sample.PNG)
-
-- 收发包函数定位：`Spawn`和`attach`模式均默认开启；
-
-> 可以使用`python r0capture.py -U -f cn.soulapp.android -v  >> soul3.txt`这样的命令将输出重定向至txt文件中稍后过滤内容
-
-![](pic/locator.png)
-
-- 客户端证书导出功能：默认开启；必须以Spawm模式运行；
-
-> 运行脚本之前必须手动给App加上存储卡读写权限；
-
-> 并不是所有App都部署了服务器验证客户端的机制，只有配置了的才会在Apk中包含客户端证书
-
-> 导出后的证书位于/sdcard/Download/包名xxx.p12路径，导出多次，每一份均可用，密码默认为：r0ysue，推荐使用[keystore-explorer](http://keystore-explorer.org/)打开查看证书。
-
-![](pic/clientcer.png)
-
-- 新增host连接方式“-H”，用于Frida-server监听在非标准端口时的连接。有些App会检测Frida标准端口，因此frida-server开在非标准端口可以绕过检测。
-
-![](pic/difport.png)
-
-## 感谢[爱吃菠菜](https://bbs.pediy.com/user-760871.htm)巨巨总结的本项目知识点
-
-![](pic/summary1.jpg)
-![](pic/summary2.jpg)
-
-
-PS：
-
-> 这个项目基于[frida_ssl_logger](https://github.com/BigFaceCat2017/frida_ssl_logger)，之所以换个名字，只是侧重点不同。 原项目的侧重点在于抓ssl和跨平台，本项目的侧重点是抓到所有的包。
-
-> 局限：部分开发实力过强的大厂或框架，采用的是自身的SSL框架，比如WebView、小程序或Flutter，这部分目前暂未支持。部分融合App本质上已经不属于安卓App，没有使用安卓系统的框架，无法支持。当然这部分App也是少数。暂不支持HTTP/2、或HTTP/3，该部分API在安卓系统上暂未普及或布署，为App自带，无法进行通用hook。各种模拟器架构、实现、环境较为复杂，建议珍爱生命、使用真机。暂未添加多进程支持，比如:service或:push等子进程，可以使用Frida的Child-gating来支持一下。支持多进程之后要考虑pcap文件的写入锁问题，可以用frida-tool的Reactor线程锁来支持一下。
-
-## 以下是原项目的简介：
-
-[https://github.com/BigFaceCat2017/frida_ssl_logger](https://github.com/BigFaceCat2017/frida_ssl_logger)
-
-### frida_ssl_logger
-ssl_logger based on frida
-for from https://github.com/google/ssl_logger
-
-### 修改内容
-1. 优化了frida的JS脚本，修复了在新版frida上的语法错误；
-2. 调整JS脚本，使其适配iOS和macOS，同时也兼容了Android；
-3. 增加了更多的选项，使其能在多种情况下使用；
-
-### 安装依赖
-```
-Python版本>=3.6
-pip install loguru
-pip install click
-```
-### Usage
-  ```shell
-    python3 ./ssl_logger.py  -U -f com.bfc.mm
-    python3 ./ssl_logger.py -v  -p test.pcap  6666
-  ````
-
+实现的forward只是对r0capture的SSL_write类型的function进行了处理，同时因为是hook的原因，并不能达到像平常代理那样的阻塞方式的拦截数据包。不过这也方便渗透测试人员对数据包的分析和测试 :)

--- a/forwarder.py
+++ b/forwarder.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+# !/usr/bin/env python
+
+__author__ = "RichardTang"
+__version__ = "1.0"
+
+import httpx
+from loguru import logger
+from urllib3.exceptions import InsecureRequestWarning
+
+class Forwarder:
+
+
+    def __init__(self, proxies):
+        self.httpx_client = httpx.Client(proxies={"https://":proxies,"http://":proxies}, verify=False, timeout=3, http2=True)
+
+
+    # int值转ip地址字符串
+    def int_to_ip(self, num):
+        s = []
+        for i in range(4):
+            s.append(str(num % 256))
+            num //= 256
+        return '.'.join(s[::-1])
+
+
+    # 处理转发请求
+    def forward(self, message, data):
+        try:
+            # 只处理Http协议的发送包
+            if (message["payload"]["function"] == "SSL_write") and (bytes("HTTP/", encoding="utf-8") in data):
+
+                # 忽略Http2的PRI请求，一般代理工具都支持处理Http2，所以这里不需要另外处理。没理解错的话 :)
+                if bytes("PRI * HTTP/2.0", encoding="utf-8") in data:
+                    return
+
+                p = message["payload"]
+
+                # 分割header和body原始数据
+                split_index_position = data.index(b'\r\n\r\n')
+                http_header_raw = data[:split_index_position]
+                http_body_raw = data[split_index_position + 4:]
+
+                # 解码HttpHeader
+                http_header = str(http_header_raw, 'utf-8').split('\r\n')
+                http_post_and_uri = http_header[0].split(" ")
+                http_method = http_post_and_uri[0]
+                http_target = "https://{}:{}{}".format(
+                    self.int_to_ip(p["dst_addr"]),
+                    p["dst_port"],
+                    http_post_and_uri[1].split(" ")[0]
+                )
+
+                # logger.info(http_header[0])
+                # logger.info(http_target)
+
+                # 解码HttpBody
+                http_body = ""
+                if len(http_body_raw.strip()) >= 1:
+                    http_body = http_body_raw
+
+                # 需要转换为dict
+                headers = {}
+                for index in range(1, len(http_header)):
+                    # 根据 : 进行切割，重新组装成dict。
+                    item = http_header[index].split(":")
+                    headers[str(item[0])] = str(item[1]).lstrip()
+
+                # 转发请求
+                self.httpx_client.request(http_method, http_target, headers=headers, data=http_body)
+
+        except Exception as e:
+            logger.info(e)
+            # logger.info(data)
+            pass

--- a/r0capture.py
+++ b/r0capture.py
@@ -370,7 +370,7 @@ Examples:
                       help="if spawned app")
     args.add_argument("-wait", "-w", type=int, metavar="<seconds>", default=0,
                       help="Time to wait for the process")
-    args.add_argument("--isForward", "-F", metavar="<[http|https|socks5]://127.0.0.1:8080>", required=False,
+    args.add_argument("--isForward", "-F", metavar="<http|https>://<host>:<port>", required=False,
                       help="Forward http request to proxy host")
 
     parsed = parser.parse_args()

--- a/r0capture.py
+++ b/r0capture.py
@@ -129,9 +129,6 @@ def show_banner():
 #                                  <bytes sent by server>)
 ssl_sessions = {}
 
-# Forward Proxy Listener Host
-proxies = {}
-
 def ssl_log(process, pcap=None, host=False, verbose=False, isUsb=False, ssllib="", isSpawn=True, wait=0, isForward=False):
     """Decrypts and logs a process's SSL traffic.
     Hooks the functions SSL_read() and SSL_write() in a given process and logs

--- a/r0capture.py
+++ b/r0capture.py
@@ -62,6 +62,8 @@ from pathlib import Path
 import frida
 from loguru import logger
 
+from forwarder import Forwarder
+
 try:
     if os.name == 'nt':
         import win_inet_pton
@@ -127,8 +129,10 @@ def show_banner():
 #                                  <bytes sent by server>)
 ssl_sessions = {}
 
+# Forward Proxy Listener Host
+proxies = {}
 
-def ssl_log(process, pcap=None, host=False, verbose=False, isUsb=False, ssllib="", isSpawn=True, wait=0):
+def ssl_log(process, pcap=None, host=False, verbose=False, isUsb=False, ssllib="", isSpawn=True, wait=0, isForward=False):
     """Decrypts and logs a process's SSL traffic.
     Hooks the functions SSL_read() and SSL_write() in a given process and logs
     the decrypted data to the console and/or to a pcap file.
@@ -243,7 +247,15 @@ def ssl_log(process, pcap=None, host=False, verbose=False, isUsb=False, ssllib="
         if pcap:
             log_pcap(pcap_file, p["ssl_session_id"], p["function"], p["src_addr"],
                      p["src_port"], p["dst_addr"], p["dst_port"], data)
+        if isForward:
+            _forwarder.forward(message, data)
 
+    if isForward:
+        try:
+            _forwarder = Forwarder(isForward)
+        except Exception as e:
+            print('Please check forward proxy host format.')
+            exit()
     if isUsb:
         try:
             device = frida.get_usb_device()
@@ -358,6 +370,8 @@ Examples:
                       help="if spawned app")
     args.add_argument("-wait", "-w", type=int, metavar="<seconds>", default=0,
                       help="Time to wait for the process")
+    args.add_argument("--isForward", "-F", metavar="<[http|https|socks5]://127.0.0.1:8080>", required=False,
+                      help="Forward http request to proxy host")
 
     parsed = parser.parse_args()
     logger.add(f"{parsed.process.replace('.','_')}-{int(time.time())}.log", rotation="500MB", encoding="utf-8", enqueue=True, retention="10 days")
@@ -370,5 +384,6 @@ Examples:
         isUsb=parsed.isUsb,
         isSpawn=parsed.isSpawn,
         ssllib=parsed.ssl,
-        wait=parsed.wait
+        wait=parsed.wait,
+        isForward=parsed.isForward
     )

--- a/r0capture.py
+++ b/r0capture.py
@@ -129,6 +129,9 @@ def show_banner():
 #                                  <bytes sent by server>)
 ssl_sessions = {}
 
+# Forward Proxy Listener Host
+proxies = {}
+
 def ssl_log(process, pcap=None, host=False, verbose=False, isUsb=False, ssllib="", isSpawn=True, wait=0, isForward=False):
     """Decrypts and logs a process's SSL traffic.
     Hooks the functions SSL_read() and SSL_write() in a given process and logs


### PR DESCRIPTION
# 功能场景

目前r0capture是以pcap和print的方式查看数据包，有时在应对渗透测试的场景下，需要用到burpsuite或yakit此类工具进行改包，方便进行数据包的分析和修改。

# 新增参数

`-F http://127.0.0.1:8080` 或 `--isForward http://127.0.0.1:8080`

`python r0capture.py -U -f package -F http://127.0.0.1:8080 -p test.pcap`

# 演示效果

![image](https://user-images.githubusercontent.com/30547741/215651947-a84a2152-96bb-4c28-837c-f8117bc08445.png)

![image](https://user-images.githubusercontent.com/30547741/215652029-9ae633da-1152-4721-93c6-9d5f7a919937.png)

# Tip

实现的forward只是对r0capture的SSL_write类型的function进行了处理，同时因为是hook的原因，并不能达到像平常代理那样的阻塞方式的拦截数据包。不过这也方便渗透测试人员对数据包的分析和测试 :)